### PR TITLE
feat: add '-w dupbuild', can warning on duplicate edges

### DIFF
--- a/src/manifest_parser.cc
+++ b/src/manifest_parser.cc
@@ -336,9 +336,24 @@ bool ManifestParser::ParseEdge(string* err) {
       return lexer_.Error("empty path", err);
     uint64_t slash_bits;
     CanonicalizePath(&path, &slash_bits);
-    if (!state_->AddOut(edge, path, slash_bits, err)) {
-      lexer_.Error(std::string(*err), err);
-      return false;
+    // if (!state_->AddOut(edge, path, slash_bits, err)) {
+    //   lexer_.Error(std::string(*err), err);
+    //   return false;
+    // }
+    if (!state_->AddOut(edge, path, slash_bits)) {
+      if (options_.dupe_edge_action_ == kDupeEdgeActionError) {
+        lexer_.Error("multiple rules generate " + path, err);
+        return false;
+      } else {
+        if (!quiet_) {
+          Warning(
+              "multiple rules generate %s. builds involving this target will "
+              "not be correct; continuing anyway",
+              path.c_str());
+        }
+        if (e - i <= static_cast<size_t>(implicit_outs))
+          --implicit_outs;
+      }
     }
   }
 

--- a/src/manifest_parser.h
+++ b/src/manifest_parser.h
@@ -31,7 +31,12 @@ enum PhonyCycleAction {
 };
 
 struct ManifestParserOptions {
-  PhonyCycleAction phony_cycle_action_ = kPhonyCycleActionWarn;
+  // PhonyCycleAction phony_cycle_action_ = kPhonyCycleActionWarn;
+  ManifestParserOptions()
+      : dupe_edge_action_(kDupeEdgeActionWarn),
+        phony_cycle_action_(kPhonyCycleActionWarn) {}
+  DupeEdgeAction dupe_edge_action_;
+  PhonyCycleAction phony_cycle_action_;
 };
 
 /// Parses .ninja files.

--- a/src/manifest_parser_test.cc
+++ b/src/manifest_parser_test.cc
@@ -330,6 +330,29 @@ TEST_F(ParserTest, CanonicalizePathsBackslashes) {
 }
 #endif
 
+TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputs) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+"rule cat\n"
+"  command = cat $in > $out\n"
+"build out1 out2: cat in1\n"
+"build out1: cat in2\n"
+"build final: cat out1\n"
+));
+  // AssertParse() checks that the generated build graph is self-consistent.
+  // That's all the checking that this test needs.
+}
+
+TEST_F(ParserTest, NoDeadPointerFromDuplicateEdge) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
+"rule cat\n"
+"  command = cat $in > $out\n"
+"build out: cat in\n"
+"build out: cat in\n"
+));
+  // AssertParse() checks that the generated build graph is self-consistent.
+  // That's all the checking that this test needs.
+}
+
 TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputsError) {
   const char kInput[] =
 "rule cat\n"
@@ -337,7 +360,10 @@ TEST_F(ParserTest, DuplicateEdgeWithMultipleOutputsError) {
 "build out1 out2: cat in1\n"
 "build out1: cat in2\n"
 "build final: cat out1\n";
-  ManifestParser parser(&state, &fs_);
+  // ManifestParser parser(&state, &fs_);
+  ManifestParserOptions parser_opts;
+  parser_opts.dupe_edge_action_ = kDupeEdgeActionError;
+  ManifestParser parser(&state, &fs_, parser_opts);
   string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("input:5: multiple rules generate out1\n", err);
@@ -352,7 +378,10 @@ TEST_F(ParserTest, DuplicateEdgeInIncludedFile) {
     "build final: cat out1\n");
   const char kInput[] =
     "subninja sub.ninja\n";
-  ManifestParser parser(&state, &fs_);
+  // ManifestParser parser(&state, &fs_);
+  ManifestParserOptions parser_opts;
+  parser_opts.dupe_edge_action_ = kDupeEdgeActionError;
+  ManifestParser parser(&state, &fs_, parser_opts);
   string err;
   EXPECT_FALSE(parser.ParseTest(kInput, &err));
   EXPECT_EQ("sub.ninja:5: multiple rules generate out1\n", err);
@@ -970,26 +999,40 @@ TEST_F(ParserTest, ImplicitOutputEmpty) {
   EXPECT_FALSE(edge->is_implicit_out(0));
 }
 
-TEST_F(ParserTest, ImplicitOutputDupeError) {
-  const char kInput[] =
+// TEST_F(ParserTest, ImplicitOutputDupeError) {
+//   const char kInput[] =
+TEST_F(ParserTest, ImplicitOutputDupe) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat\n"
 "  command = cat $in > $out\n"
-"build foo baz | foo baq foo: cat bar\n";
-  ManifestParser parser(&state, &fs_);
-  string err;
-  EXPECT_FALSE(parser.ParseTest(kInput, &err));
-  EXPECT_EQ("input:4: foo is defined as an output multiple times\n", err);
+"build foo baz | foo baq foo: cat bar\n"));
+  Edge* edge = state.LookupNode("foo")->in_edge();
+  ASSERT_EQ(edge->outputs_.size(), 3);
+  EXPECT_FALSE(edge->is_implicit_out(0));
+  EXPECT_FALSE(edge->is_implicit_out(1));
+  EXPECT_TRUE(edge->is_implicit_out(2));
+// "build foo baz | foo baq foo: cat bar\n";
+//   ManifestParser parser(&state, &fs_);
+//   string err;
+//   EXPECT_FALSE(parser.ParseTest(kInput, &err));
+//   EXPECT_EQ("input:4: foo is defined as an output multiple times\n", err);
 }
 
-TEST_F(ParserTest, ImplicitOutputDupesError) {
-  const char kInput[] =
+// TEST_F(ParserTest, ImplicitOutputDupesError) {
+//   const char kInput[] =
+TEST_F(ParserTest, ImplicitOutputDupes) {
+  ASSERT_NO_FATAL_FAILURE(AssertParse(
 "rule cat\n"
 "  command = cat $in > $out\n"
-"build foo foo foo | foo foo foo foo: cat bar\n";
-  ManifestParser parser(&state, &fs_);
-  string err;
-  EXPECT_FALSE(parser.ParseTest(kInput, &err));
-  EXPECT_EQ("input:4: foo is defined as an output multiple times\n", err);
+"build foo foo foo | foo foo foo foo: cat bar\n"));
+  Edge* edge = state.LookupNode("foo")->in_edge();
+  ASSERT_EQ(edge->outputs_.size(), 1);
+  EXPECT_FALSE(edge->is_implicit_out(0));
+// "build foo foo foo | foo foo foo foo: cat bar\n";
+//   ManifestParser parser(&state, &fs_);
+//   string err;
+//   EXPECT_FALSE(parser.ParseTest(kInput, &err));
+//   EXPECT_EQ("input:4: foo is defined as an output multiple times\n", err);
 }
 
 TEST_F(ParserTest, NoExplicitOutput) {

--- a/src/missing_deps_test.cc
+++ b/src/missing_deps_test.cc
@@ -64,9 +64,11 @@ struct MissingDependencyScannerTest : public testing::Test {
     compile_rule_.AddBinding("deps", deps_type);
     generator_rule_.AddBinding("deps", deps_type);
     Edge* header_edge = state_.AddEdge(&generator_rule_);
-    state_.AddOut(header_edge, "generated_header", 0, nullptr);
+    // state_.AddOut(header_edge, "generated_header", 0, nullptr);
+    state_.AddOut(header_edge, "generated_header", 0);
     Edge* compile_edge = state_.AddEdge(&compile_rule_);
-    state_.AddOut(compile_edge, "compiled_object", 0, nullptr);
+    // state_.AddOut(compile_edge, "compiled_object", 0, nullptr);
+    state_.AddOut(compile_edge, "compiled_object", 0);
   }
 
   void CreateGraphDependencyBetween(const char* from, const char* to) {
@@ -130,7 +132,8 @@ TEST_F(MissingDependencyScannerTest, MissingDepFixedIndirect) {
   CreateInitialState();
   // Adding an indirect dependency also fixes the issue
   Edge* intermediate_edge = state_.AddEdge(&generator_rule_);
-  state_.AddOut(intermediate_edge, "intermediate", 0, nullptr);
+  state_.AddOut(intermediate_edge, "intermediate", 0);
+  // state_.AddOut(intermediate_edge, "intermediate", 0, nullptr);
   CreateGraphDependencyBetween("compiled_object", "intermediate");
   CreateGraphDependencyBetween("intermediate", "generated_header");
   RecordDepsLogDep("compiled_object", "generated_header");

--- a/src/state.cc
+++ b/src/state.cc
@@ -133,17 +133,20 @@ void State::AddIn(Edge* edge, StringPiece path, uint64_t slash_bits) {
   node->AddOutEdge(edge);
 }
 
-bool State::AddOut(Edge* edge, StringPiece path, uint64_t slash_bits,
-                   std::string* err) {
+// bool State::AddOut(Edge* edge, StringPiece path, uint64_t slash_bits,
+//                    std::string* err) {
+bool State::AddOut(Edge* edge, StringPiece path, uint64_t slash_bits) {
   Node* node = GetNode(path, slash_bits);
-  if (Edge* other = node->in_edge()) {
-    if (other == edge) {
-      *err = path.AsString() + " is defined as an output multiple times";
-    } else {
-      *err = "multiple rules generate " + path.AsString();
-    }
+  if (node->in_edge())
     return false;
-  }
+  // if (Edge* other = node->in_edge()) {
+  //   if (other == edge) {
+  //     *err = path.AsString() + " is defined as an output multiple times";
+  //   } else {
+  //     *err = "multiple rules generate " + path.AsString();
+  //   }
+  //   return false;
+  // }
   edge->outputs_.push_back(node);
   node->set_in_edge(edge);
   node->set_generated_by_dep_loader(false);

--- a/src/state.h
+++ b/src/state.h
@@ -112,7 +112,8 @@ struct State {
   /// ensures that the generated_by_dep_loader() flag for all these nodes
   /// is set to false, to indicate that they come from the input manifest.
   void AddIn(Edge* edge, StringPiece path, uint64_t slash_bits);
-  bool AddOut(Edge* edge, StringPiece path, uint64_t slash_bits, std::string* err);
+  bool AddOut(Edge* edge, StringPiece path, uint64_t slash_bits);
+  // bool AddOut(Edge* edge, StringPiece path, uint64_t slash_bits, std::string* err);
   void AddValidation(Edge* edge, StringPiece path, uint64_t slash_bits);
   bool AddDefault(StringPiece path, std::string* error);
 

--- a/src/state_test.cc
+++ b/src/state_test.cc
@@ -36,7 +36,8 @@ TEST(State, Basic) {
   Edge* edge = state.AddEdge(rule);
   state.AddIn(edge, "in1", 0);
   state.AddIn(edge, "in2", 0);
-  state.AddOut(edge, "out", 0, nullptr);
+  state.AddOut(edge, "out", 0);
+  // state.AddOut(edge, "out", 0, nullptr);
 
   EXPECT_EQ("cat in1 in2 > out", edge->EvaluateCommand());
 


### PR DESCRIPTION
Add '-w dupbuild' support to Ninja 1.12 for OpenHarmony compilation compatibility.