### PR TITLE
docs: update openharmony docs

### DIFF
--- a/doc/openharmony/.cloudbuild.yml
+++ b/doc/openharmony/.cloudbuild.yml
@@ -47,6 +47,16 @@ rules:
     - "rust_rlib"
     - "rust_staticlib"
     - "copy"
+    - "clang_x64_solink"
+    - "mingw_x86_64_solink"
+    - "solink"
+    - "alink"
+    - "clang_x64_alink"
+    - "clang_x64_link"
+    - "link"
+    - "mingw_x86_64_alink"
+    - "mingw_x86_64_link"
+    - "stamp"
   # 远程执行但不缓存的命令（如每次需重新拉取资源的命令）
   remote_exec_rules:
   # 模糊匹配的命令（如包含特定关键词的编译命令）
@@ -54,20 +64,14 @@ rules:
     - "build_toolchain_ohos_ohos_clang_arm__rule"
     - "build_toolchain_linux_clang_x64__rule"
     - "build_toolchain_mingw_mingw_x86_64__rule"
-    - "solink"
-    - "alink"
-    - "link"
     - "asm_defines/asm_defines/defines"
     - "soft_musl_crt/crti"
     - "FREETYPE_MINOR"
-    - "-DACE_LOG_TAG=\\\"Ace\\\""
     - "compiler/optimizer/code_generator/target"
-    - "build/toolchain/rustc_wrapper.py" 
     - "QuickFixService"
     - "BundleTool"
     - "render_service_base/rs_base_blocklist"
     - "render_service_client/rs_client_blocklist"
     - "externals/libjpeg-turbo/libjpeg"
     - "externals/libjpeg-turbo/simd"
-    - "touch "
-    
+

--- a/doc/openharmony/.ninja2.conf
+++ b/doc/openharmony/.ninja2.conf
@@ -1,4 +1,3 @@
 # Copyright 2025 Mengning Software All rights reserved.  
 cloudbuild: true
-grpc_url: "grpc://localhost:1985"  
-sharebuild: false
+grpc_url: "grpc://192.168.1.12:1989"

--- a/doc/openharmony/README.md
+++ b/doc/openharmony/README.md
@@ -65,8 +65,8 @@ sudo mv /home/user/ninja2/build/ninja prebuilts/build-tools/linux-x86/bin/
 
 | 主机          | 编号   | 系统            | 内存  | 物理核数 | 逻辑CPU | 运行环境 |
 | ------------- | ---- | ------------------ | --- | ---- | ----- | ---- |
-| 源码          | lab0 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 容器   |
-| remote server | lab2 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 主机   |
+| 源码及ninja2  | lab0 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 容器   |
+| server        | lab2 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 主机   |
 | executor      | lab1 | Ubuntu 22.04.2 LTS | 32G | 12   | 16    | 容器   |
 
 # 1.操作步骤
@@ -143,94 +143,24 @@ cd ninja2
 ./build.sh build
 ```
 
-### (3) 配置 $HOME/.ninja2.conf
+### (3) 配置 ninja2
+```sh
+cd /home/openharmony
+# .cloudbuild.yml文件默认放在项目根目录下
+cp /path/to/ninja2/doc/openharmony/.cloudbuild.yml ./
+# .ninja2.conf 默认放在项目根目录下，放在$HOME/.ninja2.conf 为当前用户全局有效影响所有项目的ninja2编译
+cp /path/to/ninja2/doc/openharmony/.ninja2.conf ./
+```
+注意.ninja2.conf文件中的IP地址修改为您实际的server IP地址
 ```
 cloudbuild: true
-grpc_url: "grpc://192.168.1.12:1985"
+grpc_url: "grpc://[您实际的server IP地址]:1985"
 ```
-
-### (4) .cloudbuild.yml
-```
-# 作用：配置 RBE（远程构建执行）的命令规则
-rules:
-  # 仅本地仅执行的命令（如本地文件预处理、依赖检查）
-  local_only_rules:
-    - "CXX_COMPILER__LumeShaderCompiler"
-    - "CXX_EXECUTABLE_LINKER__LumeShaderCompiler" 
-    - "CXX_COMPILER__SPIRV-Tools-shared"
-    - "CXX_SHARED_LIBRARY_LINKER__SPIRV-Tools-shared"
-    - "CXX_COMPILER__SPIRV-Tools-static"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-static"
-    - "CXX_COMPILER__SPIRV-Tools-opt"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-opt"
-    - "CXX_COMPILER__SPIRV-Tools-reduce"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-reduce"
-    - "CXX_COMPILER__SPIRV-Tools-link"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-link"
-    - "CXX_COMPILER__SPIRV-Tools-lint"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-lint"
-    - "CXX_COMPILER__SPIRV-Tools-diff"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-diff"
-    - "CXX_COMPILER__GenericCodeGen"
-    - "CXX_STATIC_LIBRARY_LINKER__GenericCodeGen"
-    - "CXX_COMPILER__MachineIndependent"
-    - "CXX_STATIC_LIBRARY_LINKER__MachineIndependent"
-    - "CXX_COMPILER__glslang"
-    - "CXX_STATIC_LIBRARY_LINKER__glslang"
-    - "CXX_COMPILER__OSDependent"
-    - "CXX_STATIC_LIBRARY_LINKER__OSDependent"
-    - "CXX_COMPILER__OGLCompiler"
-    - "CXX_STATIC_LIBRARY_LINKER__OGLCompiler"
-    - "CXX_COMPILER__SPIRV"
-    - "CXX_STATIC_LIBRARY_LINKER__SPIRV"
-    - "CXX_COMPILER__spirv-cross-glsl"
-    - "CXX_STATIC_LIBRARY_LINKER__spirv-cross-glsl"
-    - "CXX_COMPILER__spirv-cross-core"
-    - "CXX_STATIC_LIBRARY_LINKER__spirv-cross-core"
-    - "CXX_COMPILER__LumeAssetCompiler"
-    - "CXX_EXECUTABLE_LINKER__LumeAssetCompiler"
-    - "clang_x64_rust_bin"
-    - "clang_x64_rust_macro"
-    - "clang_x64_rust_rlib"
-    - "rust_bin"
-    - "rust_cdylib"
-    - "rust_dylib"
-    - "rust_rlib"
-    - "rust_staticlib"
-    - "solink"
-    - "alink"
-    - "link"
-    - "clang_x64_solink"
-    - "clang_x64_alink"
-    - "clang_x64_link"    
-    - "mingw_x86_64_solink"
-    - "mingw_x86_64_alink"
-    - "mingw_x86_64_link"
-    - "stamp"
-    - "copy"
-  # 远程执行但不缓存的命令（如每次需重新拉取资源的命令）
-  remote_exec_rules:
-  # 模糊匹配的命令（如包含特定关键词的编译命令）
-  local_only_fuzzy:
-    - "build_toolchain_ohos_ohos_clang_arm__rule"
-    - "build_toolchain_linux_clang_x64__rule"
-    - "build_toolchain_mingw_mingw_x86_64__rule"
-    - "asm_defines/asm_defines/defines"
-    - "soft_musl_crt/crti"
-    - "FREETYPE_MINOR"
-    - "compiler/optimizer/code_generator/target"
-    - "QuickFixService"
-    - "BundleTool"
-    - "render_service_base/rs_base_blocklist"
-    - "render_service_client/rs_client_blocklist"
-    - "externals/libjpeg-turbo/libjpeg"
-    - "externals/libjpeg-turbo/simd"
-```
+cp prebuilts/build-tools/linux-x86/bin/ninja prebuilts/build-tools/linux-x86/bin/ninja-back
+rm prebuilts/build-tools/linux-x86/bin/ninja
+cp /path/to/ninja2/build/bin/ninja prebuilts/build-tools/linux-x86/bin/
 
 ### (5) 开始编译
 ```sh
-cp prebuilts/build-tools/linux-x86/bin/ninja prebuilts/build-tools/linux-x86/bin/ninja-back
-rm prebuilts/build-tools/linux-x86/bin/ninja
-cp /home/ninja2/build/bin/ninja prebuilts/build-tools/linux-x86/bin/
 ./build.sh --product-name rk3568 --ccache=false --ninja-args="-r/home/openharmony"
 ```

--- a/doc/openharmony/README.md
+++ b/doc/openharmony/README.md
@@ -6,7 +6,16 @@
 
 （1）基于docker编译
 
-[harmony编译](https://gitee.com/cloudbuild888/cloudbuild/blob/master/doc/projects/openharmony.md)
+```sh
+sudo docker pull swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
+wget -c https://repo.huaweicloud.com/openharmony/os/4.1-Release/code-v4.1-Release.tar.gz
+tar -zxvf code-v4.1-Release.tar.gz
+cd OpenHarmony-v4.1-Release/OpenHarmony
+sudo docker run -it -v $(pwd):/home/openharmony swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
+root@ada29360c83c:/home/openharmony# ./build.sh --product-name rk3568 --ccache
+```
+https://gitee.com/openharmony/docs
+开发环境容器镜像https://gitee.com/openharmony/docs/blob/master/zh-cn/device-dev/get-code/gettools-acquire.md
 
 （2）搭建环境编译
 

--- a/doc/openharmony/README.md
+++ b/doc/openharmony/README.md
@@ -61,143 +61,149 @@ sudo mv /home/user/ninja2/build/ninja prebuilts/build-tools/linux-x86/bin/
 
 ## 二、分布式编译
 
-`for openharmony-V4.1`
+`for OpenharmonyOS V4.1`
 
-### 1.运行buildbuddy
+| 主机          | 编号   | 系统            | 内存  | 物理核数 | 逻辑CPU | 运行环境 |
+| ------------- | ---- | ------------------ | --- | ---- | ----- | ---- |
+| 源码          | lab0 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 容器   |
+| remote server | lab2 | Ubuntu 22.04.5 LTS | 32G | 12   | 16    | 主机   |
+| executor      | lab1 | Ubuntu 22.04.2 LTS | 32G | 12   | 16    | 容器   |
 
-1.1 clone
+# 1.操作步骤
 
+## 1.1 运行buildbuddy
+### 1.1.1 clone
 ```sh
 git clone https://github.com/buildbuddy-io/buildbuddy.git
-# git@github.com:buildbuddy-io/buildbuddy.git
+# git clone git@github.com:buildbuddy-io/buildbuddy.git
 ```
-
-1.2 运行server
-
+### 1.1.2 运行server
 ```sh
 cd buildbuddy/
 bazel build //enterprise/server:server
 bazel run //enterprise/server:server
 ```
-
-1.3 运行executor
-
+### 1.1.3 运行executor
 ```sh
+docker pull swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
+docker run -it --network=host swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
+# 下次进入容器时使用 docker exec -it [docker-id] /bin/bash
+
+wget -c https://repo.huaweicloud.com/openharmony/os/4.1-Release/code-v4.1-Release.tar.gz
+tar -zxvf code-v4.1-Release.tar.gz
+rm code-v4.1-Release.tar.gz
+ln -s /.../Openharmony/prebuilts /tmp
+
 cd buildbuddy/
 bazel build //enterprise/server/cmd/executor:executor
 bazel run //enterprise/server/cmd/executor:executor
 ```
 
-### 2.挂载prebuilts
+## 1.2 编译
 
-2.1 nfs server
-
+**(1) 准备 OHOS 编译环境**
 ```sh
-# 1.file server
-apt install nfs-kernel-server -y
-# 确认能够读写
-chmod 777 /prebuilts
-
-# =========================== /etc/exports
-# 添加
-/........./OpenHarmony-v4.1-Release/OpenHarmony/prebuilts [clientIP]/24(rw,sync,no_root_squash,no_subtree_check)
-# ip为允许挂载的客户端IP
-# ===========================
-
-# 2.生效并启动
-exportfs -a
-exportfs -rav
-# Ubuntu/Debian
-systemctl start nfs-kernel-server
-systemctl enable nfs-kernel-server
-systemctl status nfs-kernel-server
-
-rpcinfo -p 127.0.0.1
-# 防火墙
-ufw allow 111/tcp
-ufw allow 111/udp
-ufw allow 2049/tcp
-ufw allow 2049/udp
-
-# 3.允许mountd服务
-vim /etc/default/nfs-kernel-server
-# =========================== /etc/default/nfs-kernel-server
-# 添加一行
-RPCMOUNTDOPTS="--manage-gids --port 30000"
-# ===========================
-systemctl restart nfs-kernel-server
-ufw allow 30000/tcp
-ufw allow 30000/udp
-
-# 4.允许nlockmgr服务
-rpcinfo -p 127.0.0.1 | grep nlockmgr
-ufw allow 46558/udp
-ufw allow 39029/tcp
-
-# 5.其他
-ufw reload
-ufw status
+wget -c https://repo.huaweicloud.com/openharmony/os/4.1-Release/code-v4.1-Release.tar.gz
+tar -zxvf code-v4.1-Release.tar.gz
+cd OpenHarmony-v4.1-Release/OpenHarmony
+docker run -it -v $(pwd):/home/openharmony swr.cn-south-1.myhuaweicloud.com/openharmony-docker/docker_oh_standard:3.2
 ```
 
-2.2 executor挂载prebuilts
-
+**(2) 编译 ninja2**
 ```sh
-cd /tmp
-apt install nfs-common -y
-mkdir -p prebuilts
-
-showmount -e [serverIP]
-
-mount [serverIP]:/.../OpenHarmony-v4.1-Release/OpenHarmony/prebuilts /tmp/prebuilts
-# 查看挂载信息
-df -h
-
-#开机自动挂载
-# =========================== /etc/fstab
-#在主机 B 上编辑 /etc/fstab，添加：
-[serverIP]:/data/nfs_share  /xxx  nfs  defaults  0  0
-# ===========================
-# 重新加载fstab配置
-mount -a 
-```
-
-
-> [!tip] 注
-> 测试阶段，可以直接链接prebuilts目录；
-> ln -s /.../OpenHarmony-v4.1-Release/OpenHarmony/prebuilts /tmp
-
-### 3.编译
-
-3.1 ninja2
-
-```sh
-git clone git@github.com:ninja-cloudbuild/ninja2.git
+git clone https://github.com/ninja-cloudbuild/ninja2.git
 cd ninja2
 ./build.sh build
 ```
 
-3.2 配置 $HOME/.ninja2.conf
-
+**(3) 配置 $HOME/.ninja2.conf**
 ```
-# 将 .ninja2.conf 复制到$HOME目录中
-cloud_build: true
-grpc_url: "grpc://localhost:1985"  
-share_build: false
+cloudbuild: true
+grpc_url: "grpc://192.168.1.12:1989"
 ```
 
-3.3 .cloudbuild.yml
-
+**(4) .cloudbuild.yml**
 ```
-# xxx/.cloudbuild.yml
 # 作用：配置 RBE（远程构建执行）的命令规则
-# 将 .cloudbuild.yml 文件复制到鸿蒙项目根目录下
+rules:
+  # 仅本地仅执行的命令（如本地文件预处理、依赖检查）
+  local_only_rules:
+    - "CXX_COMPILER__LumeShaderCompiler"
+    - "CXX_EXECUTABLE_LINKER__LumeShaderCompiler" 
+    - "CXX_COMPILER__SPIRV-Tools-shared"
+    - "CXX_SHARED_LIBRARY_LINKER__SPIRV-Tools-shared"
+    - "CXX_COMPILER__SPIRV-Tools-static"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-static"
+    - "CXX_COMPILER__SPIRV-Tools-opt"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-opt"
+    - "CXX_COMPILER__SPIRV-Tools-reduce"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-reduce"
+    - "CXX_COMPILER__SPIRV-Tools-link"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-link"
+    - "CXX_COMPILER__SPIRV-Tools-lint"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-lint"
+    - "CXX_COMPILER__SPIRV-Tools-diff"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV-Tools-diff"
+    - "CXX_COMPILER__GenericCodeGen"
+    - "CXX_STATIC_LIBRARY_LINKER__GenericCodeGen"
+    - "CXX_COMPILER__MachineIndependent"
+    - "CXX_STATIC_LIBRARY_LINKER__MachineIndependent"
+    - "CXX_COMPILER__glslang"
+    - "CXX_STATIC_LIBRARY_LINKER__glslang"
+    - "CXX_COMPILER__OSDependent"
+    - "CXX_STATIC_LIBRARY_LINKER__OSDependent"
+    - "CXX_COMPILER__OGLCompiler"
+    - "CXX_STATIC_LIBRARY_LINKER__OGLCompiler"
+    - "CXX_COMPILER__SPIRV"
+    - "CXX_STATIC_LIBRARY_LINKER__SPIRV"
+    - "CXX_COMPILER__spirv-cross-glsl"
+    - "CXX_STATIC_LIBRARY_LINKER__spirv-cross-glsl"
+    - "CXX_COMPILER__spirv-cross-core"
+    - "CXX_STATIC_LIBRARY_LINKER__spirv-cross-core"
+    - "CXX_COMPILER__LumeAssetCompiler"
+    - "CXX_EXECUTABLE_LINKER__LumeAssetCompiler"
+    - "clang_x64_rust_bin"
+    - "clang_x64_rust_macro"
+    - "clang_x64_rust_rlib"
+    - "rust_bin"
+    - "rust_cdylib"
+    - "rust_dylib"
+    - "rust_rlib"
+    - "rust_staticlib"
+    - "solink"
+    - "alink"
+    - "link"
+    - "clang_x64_solink"
+    - "clang_x64_alink"
+    - "clang_x64_link"    
+    - "mingw_x86_64_solink"
+    - "mingw_x86_64_alink"
+    - "mingw_x86_64_link"
+    - "stamp"
+    - "copy"
+  # 远程执行但不缓存的命令（如每次需重新拉取资源的命令）
+  remote_exec_rules:
+  # 模糊匹配的命令（如包含特定关键词的编译命令）
+  local_only_fuzzy:
+    - "build_toolchain_ohos_ohos_clang_arm__rule"
+    - "build_toolchain_linux_clang_x64__rule"
+    - "build_toolchain_mingw_mingw_x86_64__rule"
+    - "asm_defines/asm_defines/defines"
+    - "soft_musl_crt/crti"
+    - "FREETYPE_MINOR"
+    - "compiler/optimizer/code_generator/target"
+    - "QuickFixService"
+    - "BundleTool"
+    - "render_service_base/rs_base_blocklist"
+    - "render_service_client/rs_client_blocklist"
+    - "externals/libjpeg-turbo/libjpeg"
+    - "externals/libjpeg-turbo/simd"
 ```
 
-### 1.3.3 openharmony
-
+**(5) 开始编译**
 ```sh
+cp prebuilts/build-tools/linux-x86/bin/ninja prebuilts/build-tools/linux-x86/bin/ninja-back
 rm prebuilts/build-tools/linux-x86/bin/ninja
-ll prebuilts/build-tools/linux-x86/bin/ninja
-cp /.../ninja2/build/bin/ninja prebuilts/build-tools/linux-x86/bin/
-./build.sh --product-name rk3568 --ccache=false --ninja-args="-r/.../OpenHarmony-v4.1-Release/OpenHarmony"
+cp /home/ninja2/build/bin/ninja prebuilts/build-tools/linux-x86/bin/
+./build.sh --product-name rk3568 --ccache=false --ninja-args="-r/home/openharmony"
 ```


### PR DESCRIPTION
更新了 OpenHarmony 相关的文档与配置（doc/openharmony 下的 .cloudbuild.yml、.ninja2.conf、README.md），目的是让分布式/远程构建流程更完整、可复制，并调整若干默认配置与路径以配合容器化/镜像化流程。

主要变更（按文件）
1.doc/openharmony/.cloudbuild.yml
大幅扩展并细化了 rules，新增了大量 local_only_rules（各类编译器/链接器/工具与 link/solink/alink/stamp/copy 等）。
保留并扩展了 local_only_fuzzy 列表，移除了若干旧的模糊匹配项。
2.doc/openharmony/.ninja2.conf
保持 cloudbuild: true。
将 grpc_url 从 grpc://localhost:1985 改为 grpc://192.168.1.12:1985。
删除或合并了部分旧选项（如 sharebuild: false 被移除）。
3.doc/openharmony/README.md
重新组织并补充了 BuildBuddy、executor、编译流程说明，新增主机表格、docker 镜像与 wget 下载示例。
将 clone URL 改为 https；将 ninja 替换/备份流程、以及 ./build.sh 的路径和参数示例改为具体绝对路径（如 /home/ninja2、/home/openharmony）。